### PR TITLE
Correct namespace to allow "shortcut" usage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,13 +31,13 @@
   },
   "autoload": {
     "psr-4": {
-      "UuidShell\\": "src"
+      "Uuid\\": "src"
     }
   },
   "autoload-dev": {
     "psr-4": {
       "Cake\\Test\\": "vendor/cakephp/cakephp/test",
-      "UuidShell\\Test\\": "tests"
+      "Uuid\\Test\\": "tests"
     }
   }
 }

--- a/src/Shell/UuidShell.php
+++ b/src/Shell/UuidShell.php
@@ -4,7 +4,7 @@
  *
  * @package UuidShell\Shell
  */
-namespace UuidShell\Shell;
+namespace Uuid\Shell;
 
 use Cake\Console\Shell;
 use Cake\Utility\Text;

--- a/tests/TestCase/Shell/UuidShellTest.php
+++ b/tests/TestCase/Shell/UuidShellTest.php
@@ -2,12 +2,12 @@
 /**
  * Tests for the UuidShell class.
  */
-namespace UuidShell\Test\TestCase\Shell;
+namespace Uuid\Test\TestCase\Shell;
 
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\TestSuite\TestCase;
-use UuidShell\Shell\UuidShell;
+use Uuid\Shell\UuidShell;
 
 /**
  * UuidShellTest class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,6 +48,6 @@ Configure::write('App', [
 	]
 ]);
 
-Plugin::load('UuidShell', [
+Plugin::load('Uuid', [
 	'path' => dirname(dirname(__FILE__)) . DS,
 ]);


### PR DESCRIPTION
The cake command line will allow you to use `bin/cake uuid` when the namespace of the plugin and the shell name match. Currently you must use `bin/cake uuidshell.uuid`, which isn't so convenient.
